### PR TITLE
Added null check to isDarkTheme

### DIFF
--- a/src/main/java/com/jthemedetecor/MacOSThemeDetector.java
+++ b/src/main/java/com/jthemedetecor/MacOSThemeDetector.java
@@ -94,7 +94,7 @@ class MacOSThemeDetector extends OsThemeDetector {
     }
 
     private boolean isDarkTheme(String themeName) {
-        return themeNamePattern.matcher(themeName).matches();
+        return themeName != null && themeNamePattern.matcher(themeName).matches();
     }
 
     @Override


### PR DESCRIPTION
isDarkTheme will throw an error if AppleInterfaceStyle isn't readable. This results in an error in the log file, but isn't harmful in that the default works. 

This patch eliminates the log error message.