### PR TITLE
Feature/Linux KDE Plasma Desktop environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ It can be useful for example if you want to synchronize your GUI App's look and 
 > This library is inspired by the dark-theme detection in [Intellij Idea](https://github.com/JetBrains/intellij-community).
 
 # Compatibility
-It works on **Windows 10**, **MacOS Mojave** (or later) and even on **some Linux distributions**.
+It works on **Windows 10**, **MacOS Mojave** (or later) and even on **some Linux desktop environments**:
+
+- Gnome: Fully supported and tested on Ubuntu
+- KDE Plasma: For now will only support `isDark` method, tested on Ubuntu with `kde-plasma-desktop` package
 
 # Requirements
 **Java 11 or higher**

--- a/src/main/java/com/jthemedetecor/KdeThemeDetector.java
+++ b/src/main/java/com/jthemedetecor/KdeThemeDetector.java
@@ -35,15 +35,19 @@ import java.util.function.Consumer;
  */
 public class KdeThemeDetector extends OsThemeDetector {
     private static final Logger logger = LoggerFactory.getLogger(KdeThemeDetector.class);
+    /**
+     * List of the known look and feel packages, if the user use a package that is not listed in this list
+     * then will check if the package name contains `dark` regardless of the case sensitivity
+     * */
+    private static final String[] darkLookAndFeelPackages = {
+            "org.kde.breezedark.desktop", "org.kde.oxygen", "org.kde.arc-dark",
+            "org.kde.numix-dark", "org.kde.papirus-dark", "org.kde.suru-dark"
+    };
 
     @Override
     public boolean isDark() {
         try {
             String currentLookAndFeelPackageName = getCurrentLookAndFeelPackageName();
-            String[] darkLookAndFeelPackages = {
-                    "org.kde.breezedark.desktop", "org.kde.oxygen", "org.kde.arc-dark",
-                    "org.kde.numix-dark", "org.kde.papirus-dark", "org.kde.suru-dark"
-            };
 
             if (Arrays.asList(darkLookAndFeelPackages).contains(currentLookAndFeelPackageName)) {
                 return true;
@@ -66,6 +70,7 @@ public class KdeThemeDetector extends OsThemeDetector {
         // Build the complete file path
         filePath = homeDir.resolve(".config/kdeglobals").toString();
 
+        // Read the file and get the value of the property LookAndFeelPackage
         try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
             String lookAndFeelPackage = null;
             String line;

--- a/src/main/java/com/jthemedetecor/KdeThemeDetector.java
+++ b/src/main/java/com/jthemedetecor/KdeThemeDetector.java
@@ -62,16 +62,16 @@ public class KdeThemeDetector extends OsThemeDetector {
     }
 
     private String getCurrentLookAndFeelPackageName() throws IOException {
-        String filePath;
+        String kdeGlobalsFilePath;
 
         // Get user's home directory
         Path homeDir = Paths.get(System.getProperty("user.home"));
 
         // Build the complete file path
-        filePath = homeDir.resolve(".config/kdeglobals").toString();
+        kdeGlobalsFilePath = homeDir.resolve(".config/kdeglobals").toString();
 
         // Read the file and get the value of the property LookAndFeelPackage
-        try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
+        try (BufferedReader reader = new BufferedReader(new FileReader(kdeGlobalsFilePath))) {
             String lookAndFeelPackage = null;
             String line;
             while ((line = reader.readLine()) != null) {

--- a/src/main/java/com/jthemedetecor/KdeThemeDetector.java
+++ b/src/main/java/com/jthemedetecor/KdeThemeDetector.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.jthemedetecor;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+/**
+ * Used for detecting the dark theme on a Linux KDE desktop environment.
+ * Tested on Ubuntu KDE Plasma (kde-plasma-desktop).
+ *
+ * @see GnomeThemeDetector
+ */
+public class KdeThemeDetector extends OsThemeDetector {
+    private static final Logger logger = LoggerFactory.getLogger(KdeThemeDetector.class);
+
+    @Override
+    public boolean isDark() {
+        try {
+            String currentLookAndFeelPackageName = getCurrentLookAndFeelPackageName();
+            String[] darkLookAndFeelPackages = {
+                    "org.kde.breezedark.desktop", "org.kde.oxygen", "org.kde.arc-dark",
+                    "org.kde.numix-dark", "org.kde.papirus-dark", "org.kde.suru-dark"
+            };
+
+            if (Arrays.asList(darkLookAndFeelPackages).contains(currentLookAndFeelPackageName)) {
+                return true;
+            }
+
+            return currentLookAndFeelPackageName.toLowerCase().contains("dark".toLowerCase());
+
+        } catch (IOException e) {
+            logger.error("Couldn't detect Linux OS theme", e);
+            return false;
+        }
+    }
+
+    private String getCurrentLookAndFeelPackageName() throws IOException {
+        String filePath;
+
+        // Get user's home directory
+        Path homeDir = Paths.get(System.getProperty("user.home"));
+
+        // Build the complete file path
+        filePath = homeDir.resolve(".config/kdeglobals").toString();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
+            String lookAndFeelPackage = null;
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("LookAndFeelPackage=")) {
+                    lookAndFeelPackage = line.substring(line.indexOf("=") + 1);
+                    break;
+                }
+            }
+            return lookAndFeelPackage;
+        }
+    }
+
+    // TODO: Add support for the listeners, don't forgot to update the README.md if you did
+
+    @Override
+    public synchronized void registerListener(@NotNull Consumer<Boolean> darkThemeListener) {
+
+    }
+
+    @Override
+    public synchronized void removeListener(@Nullable Consumer<Boolean> darkThemeListener) {
+
+    }
+}

--- a/src/main/java/com/jthemedetecor/OsThemeDetector.java
+++ b/src/main/java/com/jthemedetecor/OsThemeDetector.java
@@ -62,6 +62,9 @@ public abstract class OsThemeDetector {
         } else if (OsInfo.isGnome()) {
             logDetection("Gnome", GnomeThemeDetector.class);
             return new GnomeThemeDetector();
+        } else if (OsInfo.isKde()) {
+            logDetection("Kde", KdeThemeDetector.class);
+            return new KdeThemeDetector();
         } else if (OsInfo.isMacOsMojaveOrLater()) {
             logDetection("MacOS", MacOSThemeDetector.class);
             return new MacOSThemeDetector();
@@ -102,7 +105,8 @@ public abstract class OsThemeDetector {
 
     @ThreadSafe
     public static boolean isSupported() {
-        return OsInfo.isWindows10OrLater() || OsInfo.isMacOsMojaveOrLater() || OsInfo.isGnome();
+        return OsInfo.isWindows10OrLater() || OsInfo.isMacOsMojaveOrLater() || OsInfo.isGnome() ||
+                OsInfo.isKde();
     }
 
     private static final class EmptyDetector extends OsThemeDetector {

--- a/src/main/java/com/jthemedetecor/util/OsInfo.java
+++ b/src/main/java/com/jthemedetecor/util/OsInfo.java
@@ -43,12 +43,17 @@ public class OsInfo {
         return hasTypeAndVersionOrHigher(PlatformEnum.MACOS, "10.14");
     }
 
+    @NotNull
+    public static String getCurrentLinuxDesktopEnvironmentName() {
+        return System.getenv("XDG_CURRENT_DESKTOP");
+    }
+
     public static boolean isGnome() {
-        return isLinux() && (
-                        queryResultContains("echo $XDG_CURRENT_DESKTOP", "gnome") ||
-                        queryResultContains("echo $XDG_DATA_DIRS | grep -Eo 'gnome'", "gnome") ||
-                        queryResultContains("ps -e | grep -E -i \"gnome\"", "gnome")
-        );
+        return isLinux() && getCurrentLinuxDesktopEnvironmentName().toLowerCase().contains("gnome");
+    }
+
+    public static boolean isKde() {
+        return isLinux() && getCurrentLinuxDesktopEnvironmentName().toLowerCase().contains("KDE".toLowerCase());
     }
 
     public static boolean hasType(PlatformEnum platformType) {


### PR DESCRIPTION
# Description

Adding support for checking is a dark mode for the Linux desktop environment without any breaking changes affecting anything else or doing further code refactoring

### The changes are:
-  Update the `README.md` to mention which Linux desktop environments are supported and what are the limitations
- Fix the desktop environment check-in `isGnome` in order to fix a bug that will happen when you have installed both KDE plasma desktop and Gnome on the same distro, the previous check will return true if the Gnome Desktop environment was installed regardless of the current used desktop environment is KDE or Gnome
- Use `System.getenv` instead of running a process to get output from the terminal for checking `isGnome` and `isKde`
- Add `isKde` method check in the `isSupported` static method and in `createDetector`
- Add `KdeThemeDetector`, since there is no way to check if the system is dark or light and we only can get the installed look and feel packages and the current used one, using this command :
`grep "^LookAndFeelPackage=" ~/.config/kdeglobals | awk -F "=" '{print $2}'`
would work and print the currently used look and feel package name, instead I used `FileReader` and read the file and got the `LookAndFeelPackage` property, the check will check if it's one of the defined dark look and feel packages, if not then it will check if it contains `dark` in a non-case sensitive way

The listeners are not supported yet as it would require more time and testing, I was hoping for an example module to simplify the development for all the developers to try and test, we might need to write a few tests too

I used a virtual machine and copied the source code into an example project to test the change since I couldn't switch to my Linux machine

KDE Plasma desktop doesn't have any straight way to check if the theme is dark or not in the terminal so searching online for `A Linux command on KDE Plasma Desktop to check if the theme is dark or light` will probably mention that you need a third party package installed on the system.

### Related issues:
- Doesn't close #31 yet since the listeners are not supported yet

### Testing
I tested the changes on Ubuntu which has the default gnome desktop environment and KDE plasma desktop installed, I switched to both and tested the changes to ensure to not create any new bugs with this feature but still more testing is welcome

I would like to thank you for your efforts for this library, I also noticed some areas for potential improvement that are outside of the purpose of this feature.
Feel free to ask for any additional changes.