### PR TITLE
Upgrade JNA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     testImplementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3'
 
     //JNA
-    implementation 'net.java.dev.jna:jna:5.10.0'
-    implementation 'net.java.dev.jna:jna-platform:5.10.0'
+    implementation 'net.java.dev.jna:jna:5.15.0'
+    implementation 'net.java.dev.jna:jna-platform:5.15.0'
 
     //JFA
     implementation ('de.jangassen:jfa:1.2.0') {


### PR DESCRIPTION
This older version of JNA is referencing an artifact that does not exist in newer versions of the JNA, it can cause build problems for projects that have projects that force using the newer versions.

```
> Could not resolve all files for configuration ':desktop:jvmRuntimeClasspath'.
   > Could not find jna-5.15.0-jpms.jar (net.java.dev.jna:jna:5.15.0).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/net/java/dev/jna/jna/5.15.0/jna-5.15.0-jpms.jar
```

The problem comes when other libs have forced it to a newer version:
```
|    +--- com.github.Dansoftowner:jSystemThemeDetector:3.8
|    |    +--- org.slf4j:slf4j-api:1.7.32 -> 2.0.16
|    |    +--- net.java.dev.jna:jna:5.10.0 -> 5.13.0
|    |    +--- net.java.dev.jna:jna-platform:5.10.0 -> 5.13.0 (*)
|    |    +--- de.jangassen:jfa:1.2.0
```