### PR TITLE
Added full KDE Plasma support, including listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ It can be useful for example if you want to synchronize your GUI App's look and 
 > This library is inspired by the dark-theme detection in [Intellij Idea](https://github.com/JetBrains/intellij-community).
 
 # Compatibility
-It works on **Windows 10**, **MacOS Mojave** (or later) and even on **some Linux distributions**.
+It works on **Windows 10**, **MacOS Mojave** (or later) and even on **some Linux desktop environments**:
+
+- Gnome: Fully supported and tested on Ubuntu
+- KDE Plasma: Fully supported and tested on Ubuntu
 
 # Requirements
 **Java 11 or higher**

--- a/src/main/java/com/jthemedetecor/KdeThemeDetector.java
+++ b/src/main/java/com/jthemedetecor/KdeThemeDetector.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.jthemedetecor;
+
+import com.jthemedetecor.util.ConcurrentHashSet;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+/**
+ * Used for detecting the dark theme on a Linux KDE desktop environment.
+ * Tested on Ubuntu KDE Plasma (kde-plasma-desktop).
+ *
+ * @author Thomas Sartre
+ * @see GnomeThemeDetector
+ */
+public class KdeThemeDetector extends OsThemeDetector {
+
+    private static final Logger logger = LoggerFactory.getLogger(KdeThemeDetector.class);
+
+    private static final String GET_THEME_CMD = "kreadconfig5 --file kdeglobals --group General --key ColorScheme";
+
+    private final Set<Consumer<Boolean>> listeners = new ConcurrentHashSet<>();
+    private final Pattern darkThemeNamePattern = Pattern.compile(".*dark.*", Pattern.CASE_INSENSITIVE);
+
+    private volatile DetectorThread detectorThread;
+
+    @Override
+    public boolean isDark() {
+        try {
+            Process process = Runtime.getRuntime().exec(GET_THEME_CMD);
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String theme = reader.readLine();
+                if (theme != null && isDarkTheme(theme)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            logger.error("Couldn't detect KDE OS theme", e);
+        }
+        return false;
+    }
+
+    private boolean isDarkTheme(String theme) {
+        return darkThemeNamePattern.matcher(theme).matches();
+    }
+
+    @Override
+    public synchronized void registerListener(@NotNull Consumer<Boolean> darkThemeListener) {
+        Objects.requireNonNull(darkThemeListener);
+        boolean listenerAdded = listeners.add(darkThemeListener);
+        boolean singleListener = listenerAdded && listeners.size() == 1;
+
+        if (singleListener || (detectorThread != null && detectorThread.isInterrupted())) {
+            detectorThread = new DetectorThread(this);
+            detectorThread.start();
+        }
+    }
+
+    @Override
+    public synchronized void removeListener(@Nullable Consumer<Boolean> darkThemeListener) {
+        listeners.remove(darkThemeListener);
+        if (listeners.isEmpty() && detectorThread != null) {
+            detectorThread.interrupt();
+            detectorThread = null;
+        }
+    }
+
+    /**
+     * Thread implementation for detecting the actually changed theme.
+     */
+    private static final class DetectorThread extends Thread {
+
+        private final KdeThemeDetector detector;
+        private boolean lastValue;
+
+        DetectorThread(@NotNull KdeThemeDetector detector) {
+            this.detector = detector;
+            this.lastValue = detector.isDark();
+            this.setName("KDE Theme Detector Thread");
+            this.setDaemon(true);
+            this.setPriority(Thread.NORM_PRIORITY - 1);
+        }
+
+        @Override
+        public void run() {
+            while (!this.isInterrupted()) {
+                boolean currentDetection = detector.isDark();
+                if (currentDetection != lastValue) {
+                    lastValue = currentDetection;
+                    for (Consumer<Boolean> listener : detector.listeners) {
+                        try {
+                            listener.accept(currentDetection);
+                        } catch (RuntimeException e) {
+                            logger.error("Caught exception during listener notification", e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/jthemedetecor/OsThemeDetector.java
+++ b/src/main/java/com/jthemedetecor/OsThemeDetector.java
@@ -63,7 +63,7 @@ public abstract class OsThemeDetector {
             logDetection("Gnome", GnomeThemeDetector.class);
             return new GnomeThemeDetector();
         } else if (OsInfo.isKde()) {
-            logDetection("Kde", KdeThemeDetector.class);
+            logDetection("KDE", KdeThemeDetector.class);
             return new KdeThemeDetector();
         } else if (OsInfo.isMacOsMojaveOrLater()) {
             logDetection("MacOS", MacOSThemeDetector.class);

--- a/src/main/java/com/jthemedetecor/OsThemeDetector.java
+++ b/src/main/java/com/jthemedetecor/OsThemeDetector.java
@@ -62,6 +62,9 @@ public abstract class OsThemeDetector {
         } else if (OsInfo.isGnome()) {
             logDetection("Gnome", GnomeThemeDetector.class);
             return new GnomeThemeDetector();
+        } else if (OsInfo.isKde()) {
+            logDetection("Kde", KdeThemeDetector.class);
+            return new KdeThemeDetector();
         } else if (OsInfo.isMacOsMojaveOrLater()) {
             logDetection("MacOS", MacOSThemeDetector.class);
             return new MacOSThemeDetector();
@@ -102,7 +105,7 @@ public abstract class OsThemeDetector {
 
     @ThreadSafe
     public static boolean isSupported() {
-        return OsInfo.isWindows10OrLater() || OsInfo.isMacOsMojaveOrLater() || OsInfo.isGnome();
+        return OsInfo.isWindows10OrLater() || OsInfo.isMacOsMojaveOrLater() || OsInfo.isGnome() || OsInfo.isKde();
     }
 
     private static final class EmptyDetector extends OsThemeDetector {

--- a/src/main/java/com/jthemedetecor/util/OsInfo.java
+++ b/src/main/java/com/jthemedetecor/util/OsInfo.java
@@ -43,16 +43,17 @@ public class OsInfo {
         return hasTypeAndVersionOrHigher(PlatformEnum.MACOS, "10.14");
     }
 
+    @NotNull
+    public static String getCurrentLinuxDesktopEnvironmentName() {
+        return System.getenv("XDG_CURRENT_DESKTOP");
+    }
+
     public static boolean isGnome() {
-        return isLinux() && (
-                        queryResultContains("echo $XDG_CURRENT_DESKTOP", "gnome") ||
-                        queryResultContains("echo $XDG_DATA_DIRS | grep -Eo 'gnome'", "gnome") ||
-                        queryResultContains("ps -e | grep -E -i \"gnome\"", "gnome")
-        );
+        return isLinux() && getCurrentLinuxDesktopEnvironmentName().toLowerCase().contains("gnome");
     }
 
     public static boolean isKde() {
-        return isLinux() && System.getenv("XDG_CURRENT_DESKTOP").toLowerCase().contains("KDE".toLowerCase());
+        return isLinux() && getCurrentLinuxDesktopEnvironmentName().toLowerCase().contains("KDE".toLowerCase());
     }
 
     public static boolean hasType(PlatformEnum platformType) {

--- a/src/main/java/com/jthemedetecor/util/OsInfo.java
+++ b/src/main/java/com/jthemedetecor/util/OsInfo.java
@@ -51,6 +51,10 @@ public class OsInfo {
         );
     }
 
+    public static boolean isKde() {
+        return isLinux() && System.getenv("XDG_CURRENT_DESKTOP").toLowerCase().contains("KDE".toLowerCase());
+    }
+
     public static boolean hasType(PlatformEnum platformType) {
         return OsInfo.platformType.equals(platformType);
     }


### PR DESCRIPTION
### Changes
- Added a `KdeThemeDetector` class
- Added a `isKde()` method to `OsInfo`
- Modified `isSupported()` in `OsThemeDetector` to include the call to `isKde()`

### Warnings:
- KDE doesn't include a way to directly tell if the apps are in dark mode or not. The closest way to do that is to check the apps color scheme through `kreadconfig5 --file kdeglobals --group General --key ColorScheme` and check if it contains "dark" or not. I may test with more color schemes later and improve the detections if needed.

### Related issues:
Closes #31 

### Credits
- to Daniel Gyorffy, I reused a lot of the `GnomeThemeDetector` code to create this
- to EchoEllet for the previous PR about KDE, I reused some code of the PR to detect the KDE environment

### Tests
Fully tested on a Ubuntu/KDE config with breeze color schemes.