### PR TITLE
Upgrade JNA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     testImplementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3'
 
     //JNA
-    implementation 'net.java.dev.jna:jna:5.15.0'
-    implementation 'net.java.dev.jna:jna-platform:5.15.0'
+    implementation 'net.java.dev.jna:jna:5.18.1'
+    implementation 'net.java.dev.jna:jna-platform:5.18.1'
 
     //JFA
     implementation ('de.jangassen:jfa:1.2.0') {


### PR DESCRIPTION
This older version of JNA is referencing an artifact that does not exist in newer versions of the JNA, it can cause build problems for projects that have projects that force using the newer versions.

```
Configuration cache state could not be cached: field `classpath` of `org.gradle.process.internal.DefaultJavaExecSpec_Decorated` bean found in field `javaExecSpec` of task `:composeApp:jvmRun` of type `org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmRun`: error writing value of type 'org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection'
> Could not resolve all files for configuration ':composeApp:jvmRuntimeClasspath'.
   > Could not find jna-5.18.1-jpms.jar (net.java.dev.jna:jna:5.18.1).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/net/java/dev/jna/jna/5.18.1/jna-5.18.1-jpms.jar
```

The problem comes when other libs have forced it to a newer version:
```
|    +--- com.github.Dansoftowner:jSystemThemeDetector:3.8
|    |    +--- net.java.dev.jna:jna:5.15.0 -> 5.18.1
|    |    +--- net.java.dev.jna:jna-platform:5.15.0 -> 5.18.1 
```
